### PR TITLE
Refactor movement to presentation system

### DIFF
--- a/Components/Visual/BattleBoardPresentationSystemComponent.gd
+++ b/Components/Visual/BattleBoardPresentationSystemComponent.gd
@@ -28,9 +28,12 @@ func _on_domain_event(eventName: StringName, data: Dictionary) -> void:
 
 func _onUnitMoved(data: Dictionary) -> void:
 	var unit: BattleBoardUnitEntity = data.get("unit")
-	var path: Array[Vector3i] = data.get("path", [])
-	if unit and unit.animComponent and not path.is_empty():
-		await unit.animComponent.playMoveSequence(path.back())
+	var fromCell: Vector3i = data.get("from", Vector3i.ZERO)
+	var toCell: Vector3i = data.get("to", Vector3i.ZERO)
+	if unit and unit.animComponent and unit.boardPositionComponent:
+		await unit.animComponent.faceDirection(fromCell, toCell)
+		unit.boardPositionComponent.setDestinationCellCoordinates(toCell)
+		await unit.boardPositionComponent.didArriveAtNewCell
 		await unit.animComponent.face_home_orientation()
 
 func _onUnitAttacked(data: Dictionary) -> void:

--- a/Resources/Commands/SpecialAttackCommand.gd
+++ b/Resources/Commands/SpecialAttackCommand.gd
@@ -288,8 +288,13 @@ func _applyKnockback(context: BattleBoardContext) -> void:
 			continue
 		print("Actually knocking back")
 		context.board.setCellOccupancy(oldPos, false, null)
-		unit.boardPositionComponent.setDestinationCellCoordinates(newPos, true)
 		context.board.setCellOccupancy(newPos, true, unit)
+		context.emitSignal(&"UnitMoved", {
+			"unit": unit,
+			"from": oldPos,
+			"to": newPos,
+			"path": []
+		})
 
 	await context.board.get_tree().create_timer(0.3).timeout
 


### PR DESCRIPTION
## Summary
- MoveCommand no longer manipulates BattleBoardPosition directly, instead updating board state and emitting UnitMoved events
- BattleBoardPresentationSystem animates movement by facing units toward targets, moving the position component, then facing them home
- SpecialAttack knockback now emits UnitMoved events for presentation handling

------
https://chatgpt.com/codex/tasks/task_e_68c600da33788324a3cc65c3648e0072