### PR TITLE
Add party resource and track Meteormyte battle data

### DIFF
--- a/AutoLoad/TurnBasedCoordinator.gd
+++ b/AutoLoad/TurnBasedCoordinator.gd
@@ -587,7 +587,7 @@ func showDebugInfo() -> void:
 
 #endregion
 
-func startPlacementPhase(party: Array[Meteormyte], againstAI: bool = false, enemyParty: Array[Meteormyte] = []) -> void:
+func startPlacementPhase(party: Party, againstAI: bool = false, enemyParty: Party = null) -> void:
 	_playerPlacementDone = false
 	_opponentPlacementDone = false
 	_againstAI = againstAI
@@ -603,20 +603,20 @@ func startPlacementPhase(party: Array[Meteormyte], againstAI: bool = false, enem
 		if placementUI:
 			placementUI.placementPhaseFinished.connect(_onPlacementFinished)
 			placementUI.beginPlacement(party)
-		if _againstAI:
+		if _againstAI and enemyParty:
 			_autoPlaceEnemy(boardEntity, enemyParty)
 
 
-func _autoPlaceEnemy(boardEntity: BattleBoardEntity3D, enemies: Array[Meteormyte]) -> void:
+func _autoPlaceEnemy(boardEntity: BattleBoardEntity3D, enemies: Party) -> void:
 	var factory: BattleBoardCommandFactory = boardEntity.components.get(&"BattleBoardCommandFactory")
 	var board: BattleBoardComponent3D = boardEntity.battleBoardGenerator
 	var width := board.width
 	var height := board.height
-	for i in range(enemies.size()):
+	for i in range(enemies.meteormytes.size()):
 		var x := i % width
 		var z := i / width
 		var cell := Vector3i(x, 0, height - 1 - z)
-		factory.intentPlaceUnit(enemies[i], cell)
+		factory.intentPlaceUnit(enemies.meteormytes[i], cell)
 	_opponentPlacementDone = true
 	_checkPlacementComplete()
 

--- a/Components/Visual/BattleBoardPlacementUIComponent.gd
+++ b/Components/Visual/BattleBoardPlacementUIComponent.gd
@@ -32,14 +32,14 @@ func _ready() -> void:
 	startPlacementButton.button_up.connect(_onStartPlacementButtonPressed)
 
 ## This is a test for singleplayer right now emulating a server architecture
-## For now we pass in a premade player party (Whenever we make the party resource)
+## For now we pass in a premade player party resource
 ## This call simulates both users connecting (one is ai) so when the player "connects" we start
 func _onStartPlacementButtonPressed() -> void:
 	startPlacementButton.disabled = true
 	#TurnBasedCoordinator.startPlacementPhase()
 
-func beginPlacement(partyUnits: Array[Meteormyte]) -> void:
-	party = partyUnits.duplicate()
+func beginPlacement(partyResource: Party) -> void:
+	party = partyResource.meteormytes.duplicate()
 	currentIndex = 0
 	_showCurrent()
 	highlighter.requestPlacementHighlights(FactionComponent.Factions.players)

--- a/Entities/TurnBased/BattleBoardUnitServerEntity.gd
+++ b/Entities/TurnBased/BattleBoardUnitServerEntity.gd
@@ -60,6 +60,10 @@ func _init(meteormyte: Meteormyte) -> void:
 	var attack := BattleBoardUnitAttackComponent.new()
 	if meteormyte and meteormyte.species_data:
 		attack.attackRange = meteormyte.species_data.baseAttackPattern
+		if meteormyte.available_attacks.size() > 0:
+			attack.basicAttack = meteormyte.available_attacks[0]
+			if meteormyte.available_attacks.size() > 1:
+				attack.specialAttacks = meteormyte.available_attacks.slice(1)
 	self.add_child(attack)
 
 	var state := UnitTurnStateComponent.new()
@@ -77,4 +81,6 @@ func _init(meteormyte: Meteormyte) -> void:
 		self.add_child(stats)
 
 		var health := MeteormyteHealthComponent.new()
+		health.startAtMaxHealth = false
+		health.currentHealth = meteormyte.current_hp
 		self.add_child(health)

--- a/Resources/Meteormyte.gd
+++ b/Resources/Meteormyte.gd
@@ -9,6 +9,8 @@ extends Resource
 @export var xp: int = 0
 @export var unique_id: int = randi()
 @export var stats: Dictionary[MeteormyteStat.StatType, MeteormyteStat] = {}
+@export var current_hp: int = 0
+@export var available_attacks: Array[AttackResource] = []
 
 func initialize_stats() -> void:
 	stats.clear()
@@ -20,6 +22,9 @@ func initialize_stats() -> void:
 	_stats_create(MeteormyteStat.StatType.SP_ATTACK, species_data.baseSpAttack)
 	_stats_create(MeteormyteStat.StatType.SP_DEFENSE, species_data.baseSpDefense)
 	_stats_create(MeteormyteStat.StatType.SPEED, species_data.baseSpeed)
+
+	var hp_stat := get_stat(MeteormyteStat.StatType.HP)
+	current_hp = hp_stat.getCurrentValue() if hp_stat else 0
 
 func _stats_create(type: MeteormyteStat.StatType, base: int) -> void:
 	var stat := MeteormyteStat.new()

--- a/Resources/Party.gd
+++ b/Resources/Party.gd
@@ -1,0 +1,14 @@
+@tool
+class_name Party
+extends Resource
+
+@export var meteormytes: Array[Meteormyte] = []
+
+func add_meteormyte(meteormyte: Meteormyte) -> void:
+	if meteormyte:
+		meteormytes.append(meteormyte)
+
+func remove_meteormyte(meteormyte: Meteormyte) -> void:
+	var idx := meteormytes.find(meteormyte)
+	if idx != -1:
+		meteormytes.remove_at(idx)


### PR DESCRIPTION
## Summary
- extend Meteormyte resource with current HP and available attacks
- introduce Party resource to group Meteormytes for server sync
- update battle setup and placement logic to use Party and initialize HP/attacks
- convert battle setup scripts to tab-based indentation per project conventions

## Testing
- `apt-get install -y godot4` *(fails: Unable to locate package godot4)*
- `apt-get install -y godot` *(fails: Unable to locate package godot)*
- `godot --headless --check-only --quit` *(fails: command not found)*
- `godot4 --headless --check-only --quit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7a8c163308324b066a31132038fed