### PR TITLE
Handle invalid party resources in placement UI

### DIFF
--- a/Components/Visual/BattleBoardPlacementUIComponent.gd
+++ b/Components/Visual/BattleBoardPlacementUIComponent.gd
@@ -4,6 +4,8 @@ extends Component
 
 const buttonStyle := preload("res://Assets/UI Pack Kenney/button.tres")
 const hoverButtonStyle := preload("res://Assets/UI Pack Kenney/hover_button.tres")
+const PLAYER_PARTY_PATH := "res://Game/Resources/TestParties/PlayerParty.tres"
+const ENEMY_PARTY_PATH := "res://Game/Resources/TestParties/EnemyParty.tres"
 
 var board: BattleBoardGeneratorComponent:
 	get:
@@ -66,14 +68,32 @@ func _ready() -> void:
 ## For now we pass in a premade player party resource
 ## This call simulates both users connecting (one is ai) so when the player "connects" we start
 func _onStartPlacementButtonPressed() -> void:
-	self.visible = false
-	boardUI.visible = true
-	startPlacementButton.disabled = true
-	
-	var playerTeam: Party = preload("res://Game/Resources/TestParties/PlayerParty.tres")
-	var enemyTeam: Party = preload("res://Game/Resources/TestParties/EnemyParty.tres")
-	
-	TurnBasedCoordinator.startPlacementPhase(playerTeam, true, enemyTeam)
+        self.visible = false
+        boardUI.visible = true
+        startPlacementButton.disabled = true
+
+        var playerTeam := _load_party_from_path(PLAYER_PARTY_PATH)
+        var enemyTeam := _load_party_from_path(ENEMY_PARTY_PATH)
+
+        if not playerTeam or not enemyTeam:
+                push_error("Unable to start placement: failed to load party resources.")
+                startPlacementButton.disabled = false
+                self.visible = true
+                boardUI.visible = false
+                return
+
+        TurnBasedCoordinator.startPlacementPhase(playerTeam, true, enemyTeam)
+
+func _load_party_from_path(party_path: String) -> Party:
+        var resource := ResourceLoader.load(party_path)
+        if resource == null:
+                return null
+
+        if resource is Party:
+                var duplicated_party := (resource as Party).duplicate(true) as Party
+                return duplicated_party if duplicated_party else resource as Party
+
+        return null
 
 func beginPlacement(partyResource: Party) -> void:
 	party = partyResource.meteormytes.duplicate()


### PR DESCRIPTION
## Summary
- centralize the test party resource paths
- add a helper that loads and validates party resources before use
- guard the placement start flow when either party resource fails to load

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8b75622708324a01b648b1ad7dd78