### PR TITLE
Decouple battle board scripts to resolve circular dependencies

### DIFF
--- a/Components/Control/BattleBoardClientStateComponent.gd
+++ b/Components/Control/BattleBoardClientStateComponent.gd
@@ -2,10 +2,10 @@
 class_name BattleBoardClientStateComponent
 extends BattleBoardStateComponent
 
-var clientUnits: Dictionary[Vector3i, BattleBoardUnitClientEntity] = {}
+var clientUnits: Dictionary[Vector3i, Entity] = {}
 
 func _updateUnitReference(cell: Vector3i, occupied: bool, occupant: Entity) -> void:
-	var clientUnit := occupant as BattleBoardUnitClientEntity
+	var clientUnit := occupant if occupant is Entity else null
 	if occupied and clientUnit:
 		clientUnits[cell] = clientUnit
 	else:
@@ -17,5 +17,5 @@ func _pruneUnitsForMissingCells() -> void:
 		if cell not in self.cells:
 			clientUnits.erase(cell)
 
-func getClientUnit(cell: Vector3i) -> BattleBoardUnitClientEntity:
+func getClientUnit(cell: Vector3i) -> Entity:
 	return clientUnits.get(cell)

--- a/Components/Gameplay/BattleBoardRulesComponent.gd
+++ b/Components/Gameplay/BattleBoardRulesComponent.gd
@@ -363,11 +363,11 @@ func canPlaceHazard(cell: Vector3i, hazardRes: HazardResource) -> bool:
 	return true
 
 ## Check if a move type can clear a hazard
-func canClearHazard(hazard: BattleBoardHazardSystemComponent.ActiveHazard, clearingType: String) -> bool:
+func canClearHazard(hazard: BattleBoardActiveHazardData, clearingType: String) -> bool:
 	if not hazard:
 		return false
 	
-	return clearingType in hazard.clearableByTypes
+	return hazard.resource and clearingType in hazard.resource.clearableByTypes
 #endregion
 
 #region Chain Attack Rules

--- a/Components/Movement/BattleBoardPositionComponent.gd
+++ b/Components/Movement/BattleBoardPositionComponent.gd
@@ -58,7 +58,7 @@ extends Component
 #region Dependencies
 
 # The battle board component attached to the BattleBoardEntity3D.
-var battleBoard: BattleBoardGeneratorComponent
+var battleBoard
 
 #endregion
 
@@ -113,7 +113,7 @@ signal didArriveAtNewCell(newDestination: Vector3i)
 
 #region Life Cycle
 
-func _init(board: BattleBoardGeneratorComponent) -> void:
+func _init(board = null) -> void:
 	battleBoard = board
 
 
@@ -126,7 +126,7 @@ func _ready() -> void:
 	if not battleBoard and self.parentEntity and self.parentEntity.get_parent():
 		var boardNode = self.parentEntity.get_parent().find_child("BattleBoardGeneratorComponent")
 		if boardNode:
-			battleBoard = boardNode.get_node(^".") as BattleBoardGeneratorComponent
+			battleBoard = boardNode.get_node(^".")
 
 	# The tileMap may be set later, if this component was loaded dynamically at runtime, or initialized by another script.
 	applyInitialCoordinates()

--- a/Components/Movement/BattleBoardServerPositionComponent.gd
+++ b/Components/Movement/BattleBoardServerPositionComponent.gd
@@ -2,7 +2,7 @@
 class_name BattleBoardServerPositionComponent
 extends Component
 
-var boardState: BattleBoardServerStateComponent
+var boardState: BattleBoardStateComponent
 
 var moveRange: BoardPattern
 
@@ -19,7 +19,7 @@ var currentCellCoordinates: Vector3i:
 var previousCellCoordinates: Vector3i = Vector3i.ZERO
 var destinationCellCoordinates: Vector3i = Vector3i.ZERO
 
-func _init(board: BattleBoardServerStateComponent = null) -> void:
+func _init(board: BattleBoardStateComponent = null) -> void:
 	boardState = board
 
 func _ready() -> void:
@@ -27,9 +27,11 @@ func _ready() -> void:
 		return
 	if not parentEntity:
 		return
-	var boardEntity := parentEntity.get_parent() as BattleBoardEntity3D
+	var boardEntity := parentEntity.get_parent()
 	if boardEntity:
-		boardState = boardEntity.serverBoardState
+		var state := boardEntity.get("serverBoardState")
+		if state is BattleBoardStateComponent:
+			boardState = state
 
 func setDestinationCellCoordinates(newCell: Vector3i, knockback: bool = false) -> bool:
 	if boardState and not boardState.isCellInBounds(newCell):

--- a/Entities/TurnBased/BattleBoardUnitClientEntity.gd
+++ b/Entities/TurnBased/BattleBoardUnitClientEntity.gd
@@ -18,7 +18,7 @@ var positionComponent: BattleBoardPositionComponent:
 #endregion
 
 ## Initializes a client-side battle board unit with the given [Meteormyte] data.
-func _init(meteormyte: Meteormyte, cell: Vector3i, board: BattleBoardGeneratorComponent) -> void:
+func _init(meteormyte: Meteormyte, cell: Vector3i, board) -> void:
 
 		var healthVis := preload("res://Components/Visual/BattleBoardUnitHealthVisualComponent.tscn").instantiate()
 		self.add_child(healthVis)

--- a/Entities/TurnBased/BattleBoardUnitServerEntity.gd
+++ b/Entities/TurnBased/BattleBoardUnitServerEntity.gd
@@ -47,7 +47,7 @@ var nickname: String:
 
 
 ## Initializes a server-side battle board unit with the given [Meteormyte] data.
-func _init(meteormyte: Meteormyte, board: BattleBoardServerStateComponent) -> void:
+func _init(meteormyte: Meteormyte, board) -> void:
 	nickname = meteormyte.nickname
 
 	var faction := FactionComponent.new()

--- a/Resources/BattleBoardActiveHazardData.gd
+++ b/Resources/BattleBoardActiveHazardData.gd
@@ -1,0 +1,8 @@
+@tool
+class_name BattleBoardActiveHazardData
+extends RefCounted
+
+var resource: HazardResource
+var turnsRemaining: int = 0
+var stacks: int = 1
+var source: Entity

--- a/Resources/BattleBoardCellData.gd
+++ b/Resources/BattleBoardCellData.gd
@@ -9,11 +9,11 @@ var isTraversable: bool = true
 var isBlocked: bool = false
 var isOccupied: bool = false
 var occupant: Entity
-var hazard: BattleBoardHazardSystemComponent.ActiveHazard
+var hazard: BattleBoardActiveHazardData
 
 #endregion
 
-func _init(traversable: bool = true, blocked: bool = false, occupied: bool = true, theOccupant: Entity = null, theHazard: BattleBoardHazardSystemComponent.ActiveHazard = null) -> void:
+func _init(traversable: bool = true, blocked: bool = false, occupied: bool = true, theOccupant: Entity = null, theHazard: BattleBoardActiveHazardData = null) -> void:
 	self.isTraversable = traversable
 	self.isBlocked = blocked
 	self.isOccupied = occupied

--- a/Resources/Commands/SpecialAttackCommand.gd
+++ b/Resources/Commands/SpecialAttackCommand.gd
@@ -189,7 +189,7 @@ func _deployHazards(context: BattleBoardContext, affectedCells: Array) -> void:
 ## Fallback hazard placement (if no hazard system)
 func _placeHazardDirect(context: BattleBoardContext, cell: Vector3i, hazardRes: HazardResource) -> void:
 	# Create active hazard data
-	var hazardData := BattleBoardHazardSystemComponent.ActiveHazard.new()
+	var hazardData := BattleBoardActiveHazardData.new()
 	hazardData.resource = hazardRes
 	hazardData.turnsRemaining = hazardRes.baseDuration
 	hazardData.stacks = 1


### PR DESCRIPTION
## Summary
- extract a reusable `BattleBoardActiveHazardData` resource so cell data no longer pulls in the hazard system script
- relax client/server board state typing to avoid direct dependencies on unit and generator scripts
- adjust position components to fetch board state dynamically and eliminate circular script references

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8d5952ff48324b69aea83e257c57e