### PR TITLE
Create selector position component at runtime

### DIFF
--- a/Entities/TurnBased/BattleBoardSelectorEntity.gd
+++ b/Entities/TurnBased/BattleBoardSelectorEntity.gd
@@ -2,12 +2,62 @@
 class_name BattleBoardSelectorEntity
 extends TurnBasedEntity
 
+const STARTING_CELL := Vector3i(2, 0, 3)
 
-# Called when the node enters the scene tree for the first time.
+var boardPositionComponent: BattleBoardPositionComponent:
+        get:
+                return components.get(&"BattleBoardPositionComponent")
+
+
 func _ready() -> void:
-	pass # Replace with function body.
+        super._ready()
+
+        var positionComponent := boardPositionComponent
+        if not positionComponent:
+                positionComponent = createPositionComponent()
+        elif positionComponent.currentCellCoordinates != STARTING_CELL:
+                positionComponent.destinationCellCoordinates = STARTING_CELL
+                positionComponent.snapEntityPositionToTile(STARTING_CELL)
+
+        if positionComponent:
+                updateSelectorComponent(positionComponent)
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(_delta: float) -> void:
-	pass
+func createPositionComponent() -> BattleBoardPositionComponent:
+        var board := findBoardGenerator()
+        if not board:
+                printWarning("BattleBoardSelectorEntity could not find a BattleBoardGeneratorComponent to initialize its position component.")
+                return null
+
+        var positionComponent := BattleBoardPositionComponent.new(board)
+        positionComponent.name = "BattleBoardPositionComponent"
+        positionComponent.setInitialCoordinatesFromEntityPosition = false
+        positionComponent.initialDestinationCoordinates = STARTING_CELL
+        positionComponent.destinationCellCoordinates = STARTING_CELL
+
+        add_child(positionComponent)
+        positionComponent.snapEntityPositionToTile(STARTING_CELL)
+
+        return positionComponent
+
+
+func findBoardGenerator() -> BattleBoardGeneratorComponent:
+        var boardEntity := get_parent()
+
+        if boardEntity is BattleBoardEntity3D:
+                var generator := (boardEntity as BattleBoardEntity3D).battleBoardGenerator
+                if generator:
+                        return generator
+
+        if boardEntity is Entity:
+                var fallback := (boardEntity as Entity).findFirstChildOfType(BattleBoardGeneratorComponent)
+                if fallback:
+                        return fallback as BattleBoardGeneratorComponent
+
+        return null
+
+
+func updateSelectorComponent(positionComponent: BattleBoardPositionComponent) -> void:
+        var selectorComponent := components.get(&"BattleBoardSelectorComponent3D") as BattleBoardSelectorComponent3D
+        if selectorComponent:
+                selectorComponent.currentCell = positionComponent.currentCellCoordinates

--- a/Entities/TurnBased/BattleBoardSelectorEntity.tscn
+++ b/Entities/TurnBased/BattleBoardSelectorEntity.tscn
@@ -1,10 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://7jcht5vta2uh"]
+[gd_scene load_steps=2 format=3 uid="uid://7jcht5vta2uh"]
 
 [ext_resource type="Script" uid="uid://b54qt332e38du" path="res://Entities/TurnBased/BattleBoardSelectorEntity.gd" id="1_1mbhb"]
-[ext_resource type="PackedScene" uid="uid://ob3s2kpnk833" path="res://Components/Movement/BattleBoardPositionComponent.tscn" id="2_0l81q"]
 
 [node name="BattleBoardSelectorEntity" type="Node3D" groups=["entities", "turnBased"]]
 script = ExtResource("1_1mbhb")
 
-[node name="BattleBoardPositionComponent" parent="." instance=ExtResource("2_0l81q")]
-script = null


### PR DESCRIPTION
## Summary
- instantiate the selector's BattleBoardPositionComponent in code by resolving the board generator
- initialize the selector at cell (2, 0, 3) and keep its companion component in sync
- remove the unused scene instance of the position component

## Testing
- `godot --headless --check-only` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c98745ba308324bc63423691c0d662