### PR TITLE
Refactor attack command presentation handling

### DIFF
--- a/Resources/Commands/AttackCommand.gd
+++ b/Resources/Commands/AttackCommand.gd
@@ -8,135 +8,123 @@ var targetCell: Vector3i
 var target: Entity
 var damageDealt: int = 0
 
+var _defaultAttackResource: AttackResource
+
 func _init() -> void:
 	commandName = "Attack"
+	requiresAnimation = false
 
 func canExecute(context: BattleBoardContext) -> bool:
 	if not attacker:
 		return false
-	
+
 	var state := attacker.components.get(&"UnitTurnStateComponent") as UnitTurnStateComponent
 	if not state or not state.canAct():
 		commandFailed.emit("Unit cannot act")
 		return false
-	
+
 	# Get target at cell
 	target = context.boardState.getOccupant(targetCell)
 	if not target:
 		commandFailed.emit("No target at cell")
 		return false
-	
+
 	# Validate via targeting policy TODO?
 	#var targetingPolicy: = context.policies.get(&"TargetingPolicy") as TargetingPolicy
 	#if not targetingPolicy.isValidTarget(attacker, target, targetCell):
 		#commandFailed.emit("Invalid target")
 		#return false
-	
+
 	if not context.rules.isValidAttack(attacker.boardPositionComponent.currentCellCoordinates, targetCell):
 		commandFailed.emit("Invalid Attack Target")
 		return false
-	
+
 	return true
 
 func execute(context: BattleBoardContext) -> void:
 	print("ATTACK COMMAND EXECUTE:")
 	commandStarted.emit()
-	
+
 	# Mark attacker as exhausted and clear highlights
-	attacker.stateComponent.markExhausted()
-	context.highlighter.clearHighlights()
-	
-	# Get stats components
-	var attackerStats := attacker.components.get(&"MeteormyteStatsComponent") as MeteormyteStatsComponent
-	var targetUnit := target as BattleBoardUnitClientEntity
-	var targetStats := targetUnit.components.get(&"MeteormyteStatsComponent") as MeteormyteStatsComponent if targetUnit else null
-	
-	# Track death states
+	if attacker.stateComponent:
+		attacker.stateComponent.markExhausted()
+	if context.highlighter:
+		context.highlighter.clearHighlights()
+
+	var resolver := _getDamageResolver(context)
+	var attackerUnit := attacker
+	var targetUnit := target as BattleBoardUnitServerEntity
+	var attackerCell := attackerUnit.boardPositionComponent.currentCellCoordinates if attackerUnit and attackerUnit.boardPositionComponent else targetCell
+
+	var attackerHealth := attackerUnit.healthComponent if attackerUnit else null
+	var targetHealth := targetUnit.healthComponent if targetUnit else null
+
+	var attackerDamage: int = 0
+	var counterDamage: int = 0
 	var targetDied: bool = false
 	var attackerDied: bool = false
-	
-	# Calculate attacker's damage
-	var attackerDamage: int = 10  # Fallback
-	if attackerStats and targetStats:
-		var defenseStat := targetStats.getMeteormyteStat(MeteormyteStat.StatType.DEFENSE)
-		var defenseValue := defenseStat.getCurrentValue() if defenseStat else 0
-		attackerDamage = attackerStats.calculateDamage(defenseValue, 40, false)  # 40 = basic attack power
-	
-	# Play attacker's animation
-	await attacker.animComponent.playAttackSequence(attacker, target, attackerDamage)
-	
-	# Apply damage to target
-	var targetHealth := target.components.get(&"MeteormyteHealthComponent") as MeteormyteHealthComponent
-	var targetAnim := target.components.get(&"InsectorAnimationComponent") as InsectorAnimationComponent
-	
-	if targetHealth:
+
+	if attackerUnit and targetUnit and targetHealth:
+		var attackRes := _getBasicAttackResource(attackerUnit)
+		attackerDamage = resolver.calculateDamage(attackerUnit, targetUnit, attackRes)
 		targetHealth.takeDamage(attackerDamage)
-		
-		# Show damage number
-		if targetAnim and attackerDamage > 0:
-			targetAnim.showDamageNumber(attackerDamage)
-		if attacker.attackComponent and attacker.attackComponent.venemous:
-			targetAnim.play_poison_puff(6)
-		
-		# Check if target died
-		if not targetHealth.isAlive():
-			targetDied = true
-			await _handleTargetDeath(context, targetUnit, targetAnim)
-	
-	# Counter-attack if target is still alive
-	var counterDamage: int = 0
-	if targetHealth and targetHealth.isAlive() and targetStats and attackerStats:
-		var attackerDefense := attackerStats.getMeteormyteStat(MeteormyteStat.StatType.DEFENSE)
-		var attackerDefenseValue := attackerDefense.getCurrentValue() if attackerDefense else 0
-		counterDamage = targetStats.calculateDamage(attackerDefenseValue, 40, false)
-		
-		# Play counter animation
-		await targetUnit.animComponent.playAttackSequence(targetUnit, attacker, counterDamage)
-		
-		# Apply counter damage
-		var attackerHealth := attacker.components.get(&"MeteormyteHealthComponent") as MeteormyteHealthComponent
-		var attackerAnim := attacker.components.get(&"InsectorAnimationComponent") as InsectorAnimationComponent
-		
-		if attackerHealth:
-			attackerHealth.takeDamage(counterDamage)
-			
-			# Show damage number
-			if attackerAnim and counterDamage > 0:
-				attackerAnim.showDamageNumber(counterDamage)
-	
-	# Face home orientation (only for survivors)
-	if not attackerDied:
-		attacker.animComponent.face_home_orientation()
-		if not targetDied and is_instance_valid(targetUnit):
-				await targetUnit.animComponent.face_home_orientation()
-	
-	# Store total damage dealt for the event
+		targetDied = not targetHealth.isAlive()
+
+	if targetUnit and targetHealth and targetHealth.isAlive() and attackerHealth:
+		var counterRes := _getBasicAttackResource(targetUnit)
+		counterDamage = resolver.calculateDamage(targetUnit, attackerUnit, counterRes)
+		attackerHealth.takeDamage(counterDamage)
+		attackerDied = not attackerHealth.isAlive()
+
 	damageDealt = attackerDamage
-	
-	# Emit domain event with both damage values
+
+	var venomous := false
+	if attackerUnit and attackerUnit.attackComponent:
+		venomous = attackerUnit.attackComponent.venemous
+
 	context.emitSignal(&"UnitAttacked", {
 		"attacker": attacker,
 		"target": target,
+		"attackerCell": attackerCell,
+		"targetCell": targetCell,
 		"damage": attackerDamage,
 		"counterDamage": counterDamage,
 		"targetDied": targetDied,
-		"attackerDied": attackerDied
+		"attackerDied": attackerDied,
+		"attackerVenomous": venomous
 	})
-	
+
+	if targetDied:
+		if context.boardState:
+			context.boardState.setCellOccupancy(targetCell, false, null)
+		if is_instance_valid(targetUnit):
+			targetUnit.queue_free()
+
+	if attackerDied:
+		if context.boardState:
+			context.boardState.setCellOccupancy(attackerCell, false, null)
+		if is_instance_valid(attackerUnit):
+			attackerUnit.queue_free()
+
 	commandCompleted.emit()
 
-## Handle a single unit death
-func _handleTargetDeath(context: BattleBoardContext, unit: BattleBoardUnitClientEntity, anim: InsectorAnimationComponent) -> void:
-	# Play death animation if available
-	if anim and anim.skin:
-		var tw := anim.create_tween()
-		tw.tween_property(anim.skin, "rotation:z", deg_to_rad(90), anim.die_animation_time)
-		tw.parallel().tween_property(anim.skin, "modulate:a", 0.0, anim.die_animation_time)
-		await tw.finished
-	
-	# Remove the unit
-	if is_instance_valid(unit):
-		unit.queue_free()
+func _getDamageResolver(context: BattleBoardContext) -> BattleDamageResolver:
+	if context.damageResolver:
+		return context.damageResolver
+	var resolver := BattleDamageResolver.new()
+	context.damageResolver = resolver
+	return resolver
+
+func _getBasicAttackResource(unit: BattleBoardUnitServerEntity) -> AttackResource:
+	if unit and unit.attackComponent and unit.attackComponent.basicAttack:
+		return unit.attackComponent.basicAttack
+	if not _defaultAttackResource:
+		_defaultAttackResource = AttackResource.new()
+		_defaultAttackResource.attackName = "Basic Attack"
+		_defaultAttackResource.baseDamage = 40
+		_defaultAttackResource.attackType = AttackResource.AttackType.PHYSICAL
+		_defaultAttackResource.interactionType = AttackResource.InteractionType.MELEE
+	return _defaultAttackResource
 
 func canUndo() -> bool:
 	return false


### PR DESCRIPTION
## Summary
- refactor AttackCommand to delegate damage calculations to the shared damage resolver and emit presentation-focused data
- move attack, counter, poison, and death animation handling into the battle board presentation system with client-side death cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca460fd8b08324b37a7bd4c9960dbb