### PR TITLE
Remove custom Vector3i serialization from BoardPattern

### DIFF
--- a/Resources/AttackResource.gd
+++ b/Resources/AttackResource.gd
@@ -7,12 +7,12 @@ enum AttackType {
 	PHYSICAL,
 	SPECIAL,
 	MIXED
-}
+	}
 
 enum InteractionType {
 	MELEE,
 	RANGED
-}
+	}
 
 enum AOEType {
 	POINT,        # Single target
@@ -21,27 +21,27 @@ enum AOEType {
 	PIERCING,     # Line that continues past target
 	CONE,         # Cone spreading from attacker
 	CHAIN         # Jumps between targets
-}
+	}
 
 enum VFXOrientation {
 	ALONG_X,  # Effect plays along X axis
 	ALONG_Y,  # Effect plays along Y axis
 	ALONG_Z,  # Effect plays along Z axis
 	CUSTOM    # Use custom rotation offsets
-}
+	}
 
 enum VFXType {
 	BEAM,
 	PROJECTILE,
 	POINT,
 	AREA
-}
+	}
 
 enum Typing {
 	FIRE,
 	WATER,
 	GRASS,
-}
+	}
 
 @export_group("Basic Properties")
 @export var attackName: String = "Unknown Attack"
@@ -95,6 +95,9 @@ enum Typing {
 @export var drainsHealth: bool = false  # Heals attacker for damage dealt
 @export var ignoresDefense: bool = false  # True damage
 
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "AttackResource"
+
 ## Get the actual range pattern (for highlighting)
 func getRangePattern() -> Array[Vector3i]:
 	if rangePattern:
@@ -105,6 +108,132 @@ func getRangePattern() -> Array[Vector3i]:
 func canReachCell(origin: Vector3i, target: Vector3i) -> bool:
 	if not rangePattern:
 		return origin.distance_to(target) <= 1  # Default melee range
-	
+
 	var offset := target - origin
 	return offset in rangePattern.offsets
+
+func toDict() -> Dictionary:
+
+	var status_paths: Array = []
+	for status in statusEffects:
+		status_paths.append(_resource_to_path(status))
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"attackName": attackName,
+		"description": description,
+		"icon": _resource_to_path(icon),
+		"baseDamage": baseDamage,
+		"accuracy": accuracy,
+		"damageType": int(damageType),
+		"attackType": int(attackType),
+		"interactionType": int(interactionType),
+		"rangePattern": _resource_to_path(rangePattern),
+		"requiresTarget": requiresTarget,
+		"canTargetEmpty": canTargetEmpty,
+		"hitsAllies": hitsAllies,
+		"aoeType": int(aoeType),
+		"aoePattern": _resource_to_path(aoePattern),
+		"chainCount": chainCount,
+		"chainRange": chainRange,
+		"statusEffects": status_paths,
+		"statusChance": statusChance,
+		"hazardResource": _resource_to_path(hazardResource),
+		"hazardChance": hazardChance,
+		"knockback": knockback,
+		"superKnockback": superKnockback,
+		"knockbackDistance": knockbackDistance,
+		"vfxScene": _resource_to_path(vfxScene),
+		"secondaryVFX": _resource_to_path(secondaryVFX),
+		"impactVFX": _resource_to_path(impactVFX),
+		"vfxType": int(vfxType),
+		"vfxScale": vfxScale,
+		"vfxHeight": vfxHeight,
+		"vfxOrientation": int(vfxOrientation),
+		"vfxRotationOffset": _vector3_to_dict(vfxRotationOffset),
+		"animationName": animationName,
+		"animationTime": animationTime,
+		"selfDamagePercent": selfDamagePercent,
+		"drainsHealth": drainsHealth,
+		"ignoresDefense": ignoresDefense
+	}
+
+static func fromDict(data: Dictionary) -> AttackResource:
+
+	var attack := AttackResource.new()
+	attack.attackName = data.get("attackName", attack.attackName)
+	attack.description = data.get("description", attack.description)
+	attack.icon = _load_resource(data.get("icon", ""))
+	attack.baseDamage = data.get("baseDamage", attack.baseDamage)
+	attack.accuracy = data.get("accuracy", attack.accuracy)
+	attack.damageType = Typing(data.get("damageType", int(attack.damageType)))
+	attack.attackType = AttackType(data.get("attackType", int(attack.attackType)))
+	attack.interactionType = InteractionType(data.get("interactionType", int(attack.interactionType)))
+	attack.rangePattern = _load_resource(data.get("rangePattern", ""))
+	attack.requiresTarget = data.get("requiresTarget", attack.requiresTarget)
+	attack.canTargetEmpty = data.get("canTargetEmpty", attack.canTargetEmpty)
+	attack.hitsAllies = data.get("hitsAllies", attack.hitsAllies)
+	attack.aoeType = AOEType(data.get("aoeType", int(attack.aoeType)))
+	attack.aoePattern = _load_resource(data.get("aoePattern", ""))
+	attack.chainCount = data.get("chainCount", attack.chainCount)
+	attack.chainRange = data.get("chainRange", attack.chainRange)
+
+	attack.statusEffects.clear()
+	for status_path in data.get("statusEffects", []):
+		if typeof(status_path) == TYPE_STRING and not status_path.is_empty():
+			var status: StatusEffectResource = _load_resource(status_path)
+			if status:
+				attack.statusEffects.append(status)
+
+	attack.statusChance = data.get("statusChance", attack.statusChance)
+	attack.hazardResource = _load_resource(data.get("hazardResource", ""))
+	attack.hazardChance = data.get("hazardChance", attack.hazardChance)
+	attack.knockback = data.get("knockback", attack.knockback)
+	attack.superKnockback = data.get("superKnockback", attack.superKnockback)
+	attack.knockbackDistance = data.get("knockbackDistance", attack.knockbackDistance)
+	attack.vfxScene = _load_resource(data.get("vfxScene", ""))
+	attack.secondaryVFX = _load_resource(data.get("secondaryVFX", ""))
+	attack.impactVFX = _load_resource(data.get("impactVFX", ""))
+	attack.vfxType = VFXType(data.get("vfxType", int(attack.vfxType)))
+	attack.vfxScale = data.get("vfxScale", attack.vfxScale)
+	attack.vfxHeight = data.get("vfxHeight", attack.vfxHeight)
+	attack.vfxOrientation = VFXOrientation(data.get("vfxOrientation", int(attack.vfxOrientation)))
+	attack.vfxRotationOffset = _vector3_from_dict(data.get("vfxRotationOffset", {}), attack.vfxRotationOffset)
+	attack.animationName = data.get("animationName", attack.animationName)
+	attack.animationTime = data.get("animationTime", attack.animationTime)
+	attack.selfDamagePercent = data.get("selfDamagePercent", attack.selfDamagePercent)
+	attack.drainsHealth = data.get("drainsHealth", attack.drainsHealth)
+	attack.ignoresDefense = data.get("ignoresDefense", attack.ignoresDefense)
+
+	return attack
+
+static func _resource_to_path(resource: Resource) -> String:
+
+	if resource and not resource.resource_path.is_empty():
+		return resource.resource_path
+	return ""
+
+static func _load_resource(path: String) -> Resource:
+
+	if typeof(path) != TYPE_STRING or path.is_empty():
+		return null
+	return ResourceLoader.load(path)
+
+static func _vector3_to_dict(value: Vector3) -> Dictionary:
+
+	return {
+		"x": value.x,
+		"y": value.y,
+		"z": value.z
+	}
+
+static func _vector3_from_dict(data: Variant, default_value: Vector3) -> Vector3:
+
+	if data is Dictionary:
+		return Vector3(
+			float(data.get("x", default_value.x)),
+			float(data.get("y", default_value.y)),
+			float(data.get("z", default_value.z))
+		)
+	return default_value

--- a/Resources/BoardPattern.gd
+++ b/Resources/BoardPattern.gd
@@ -17,4 +17,27 @@ extends GameplayResourceBase
 func contains(offset: Vector3i) -> bool:
 	return offsets.has(offset)
 
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "BoardPattern"
+
+func toDict() -> Dictionary:
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"offsets": offsets.duplicate()
+	}
+
+static func fromDict(data: Dictionary) -> BoardPattern:
+
+	var pattern := BoardPattern.new()
+	var offset_data := data.get("offsets", [])
+	pattern.offsets.clear()
+	if offset_data is Array:
+		for entry in offset_data:
+			if entry is Vector3i:
+				pattern.offsets.append(entry)
+
+	return pattern
+
 #endregion

--- a/Resources/GemData.gd
+++ b/Resources/GemData.gd
@@ -10,21 +10,24 @@ enum GemQuality {
 	RARE,       # Blue - Max Level 15
 	EPIC,       # Purple - Max Level 20
 	LEGENDARY   # Gold - Max Level 20 + bonuses
-}
+	}
 
 enum GemCut {
-	UNCUT,
-	BRILLIANT,  # +ATK/SpATK, -DEF/SpDEF
-	STURDY,     # +DEF/SpDEF, -ATK/SpATK
-	SWIFT,      # +Speed, -HP
-	VITAL,      # +HP, -Speed
-	BALANCED,   # +All stats slightly
-	CUSTOM      # Species-specific
-}
+UNCUT,
+BRILLIANT,  # +ATK/SpATK, -DEF/SpDEF
+STURDY,     # +DEF/SpDEF, -ATK/SpATK
+SWIFT,      # +Speed, -HP
+VITAL,      # +HP, -Speed
+BALANCED,   # +All stats slightly
+CUSTOM      # Species-specific
+	}
 
 @export var quality: GemQuality = GemQuality.COMMON
 @export var cut: GemCut = GemCut.UNCUT
 @export var customCutName: String = ""
+
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "GemData"
 
 ## Returns the maximum level this gem quality supports
 func getMaxLevel() -> int:
@@ -109,3 +112,21 @@ func getQualityColor() -> Color:
 			return Color.GOLD
 		_:
 			return Color.WHITE
+
+func toDict() -> Dictionary:
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"quality": int(quality),
+		"cut": int(cut),
+		"customCutName": customCutName
+	}
+
+static func fromDict(data: Dictionary) -> GemData:
+
+	var gem := GemData.new()
+	gem.quality = GemQuality(data.get("quality", int(gem.quality)))
+	gem.cut = GemCut(data.get("cut", int(gem.cut)))
+	gem.customCutName = data.get("customCutName", gem.customCutName)
+	return gem

--- a/Resources/HazardResource.gd
+++ b/Resources/HazardResource.gd
@@ -26,3 +26,64 @@ extends Resource
 @export var affectsFactions: int = -1  # Bitmask: -1 affects all, or specific faction bits
 @export var blockMovement: bool = false  # Can't move through it
 @export var blockVision: bool = false  # Blocks line of sight
+
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "HazardResource"
+
+
+func toDict() -> Dictionary:
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"hazardName": hazardName,
+		"icon": _resource_to_path(icon),
+		"vfxScene": _resource_to_path(vfxScene),
+		"baseDuration": baseDuration,
+		"maxStacks": maxStacks,
+		"stackable": stackable,
+		"damageOnEnter": damageOnEnter,
+		"damagePerTurn": damagePerTurn,
+		"statusEffectOnEnter": _resource_to_path(statusEffectOnEnter),
+		"statusEffectPerTurn": _resource_to_path(statusEffectPerTurn),
+		"clearableByTypes": clearableByTypes.duplicate(),
+		"clearsOnExit": clearsOnExit,
+		"affectsFactions": affectsFactions,
+		"blockMovement": blockMovement,
+		"blockVision": blockVision
+	}
+
+static func fromDict(data: Dictionary) -> HazardResource:
+
+	var hazard := HazardResource.new()
+	hazard.hazardName = data.get("hazardName", hazard.hazardName)
+	hazard.icon = _load_resource(data.get("icon", ""))
+	hazard.vfxScene = _load_resource(data.get("vfxScene", ""))
+	hazard.baseDuration = data.get("baseDuration", hazard.baseDuration)
+	hazard.maxStacks = data.get("maxStacks", hazard.maxStacks)
+	hazard.stackable = data.get("stackable", hazard.stackable)
+	hazard.damageOnEnter = data.get("damageOnEnter", hazard.damageOnEnter)
+	hazard.damagePerTurn = data.get("damagePerTurn", hazard.damagePerTurn)
+	hazard.statusEffectOnEnter = _load_resource(data.get("statusEffectOnEnter", ""))
+	hazard.statusEffectPerTurn = _load_resource(data.get("statusEffectPerTurn", ""))
+	var clearable_variant := data.get("clearableByTypes", hazard.clearableByTypes)
+	if clearable_variant is Array:
+		hazard.clearableByTypes = clearable_variant.duplicate()
+	hazard.clearsOnExit = data.get("clearsOnExit", hazard.clearsOnExit)
+	hazard.affectsFactions = data.get("affectsFactions", hazard.affectsFactions)
+	hazard.blockMovement = data.get("blockMovement", hazard.blockMovement)
+	hazard.blockVision = data.get("blockVision", hazard.blockVision)
+	return hazard
+
+static func _resource_to_path(resource: Resource) -> String:
+
+	if resource and not resource.resource_path.is_empty():
+		return resource.resource_path
+	return ""
+
+static func _load_resource(path: String) -> Resource:
+
+	if typeof(path) != TYPE_STRING or path.is_empty():
+		return null
+	return ResourceLoader.load(path)
+

--- a/Resources/Meteormyte.gd
+++ b/Resources/Meteormyte.gd
@@ -12,6 +12,9 @@ extends Resource
 @export var current_hp: int = 0
 @export var available_attacks: Array[AttackResource] = []
 
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "Meteormyte"
+
 func initialize_stats() -> void:
 	stats.clear()
 	if not species_data:
@@ -36,3 +39,71 @@ func _stats_create(type: MeteormyteStat.StatType, base: int) -> void:
 
 func get_stat(type: MeteormyteStat.StatType) -> MeteormyteStat:
 	return stats.get(type)
+
+func toDict() -> Dictionary:
+	var stats_data: Array = []
+	for stat_key in stats.keys():
+		var stat: MeteormyteStat = stats[stat_key]
+		if stat:
+			stats_data.append(stat.toDict())
+
+	var attack_paths: Array = []
+	for attack in available_attacks:
+		attack_paths.append(_resource_to_path(attack))
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"species_data": _resource_to_path(species_data),
+		"gem_data": _resource_to_path(gem_data),
+		"nickname": nickname,
+		"level": level,
+		"xp": xp,
+		"unique_id": unique_id,
+		"stats": stats_data,
+		"current_hp": current_hp,
+		"available_attacks": attack_paths
+	}
+
+static func fromDict(data: Dictionary) -> Meteormyte:
+
+	var meteormyte := Meteormyte.new()
+	meteormyte.nickname = data.get("nickname", meteormyte.nickname)
+	meteormyte.level = data.get("level", meteormyte.level)
+	meteormyte.xp = data.get("xp", meteormyte.xp)
+	meteormyte.unique_id = data.get("unique_id", meteormyte.unique_id)
+	meteormyte.current_hp = data.get("current_hp", meteormyte.current_hp)
+
+	meteormyte.species_data = _load_resource(data.get("species_data", ""))
+	meteormyte.gem_data = _load_resource(data.get("gem_data", ""))
+
+	meteormyte.stats.clear()
+	for stat_dict in data.get("stats", []):
+		if stat_dict is Dictionary:
+			var stat := MeteormyteStat.fromDict(stat_dict)
+			if stat:
+				meteormyte.stats[stat.statType] = stat
+
+	if meteormyte.stats.is_empty() and meteormyte.species_data:
+		meteormyte.initialize_stats()
+
+	meteormyte.available_attacks.clear()
+	for attack_path in data.get("available_attacks", []):
+		if typeof(attack_path) == TYPE_STRING and not attack_path.is_empty():
+			var attack: AttackResource = _load_resource(attack_path)
+			if attack:
+				meteormyte.available_attacks.append(attack)
+
+	return meteormyte
+
+static func _resource_to_path(resource: Resource) -> String:
+
+	if resource and not resource.resource_path.is_empty():
+		return resource.resource_path
+	return ""
+
+static func _load_resource(path: String) -> Resource:
+
+	if typeof(path) != TYPE_STRING or path.is_empty():
+		return null
+	return ResourceLoader.load(path)

--- a/Resources/MeteormyteSpeciesData.gd
+++ b/Resources/MeteormyteSpeciesData.gd
@@ -36,6 +36,9 @@ extends Resource
 @export var hiddenAbility: String = ""
 @export var learneableAbilities: Array[String] = []
 
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "MeteormyteSpeciesData"
+
 func getUpgradesForLevel(level: int) -> Array[MeteormyteLevelUpgrade]:
 	match level:
 		5:
@@ -48,3 +51,91 @@ func getUpgradesForLevel(level: int) -> Array[MeteormyteLevelUpgrade]:
 			return level20Upgrades
 		_:
 			return []
+
+func toDict() -> Dictionary:
+
+	var data := {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"speciesName": speciesName,
+		"speciesID": speciesID,
+		"description": description,
+		"icon": _resource_to_path(icon),
+		"model": _resource_to_path(model),
+		"baseHP": baseHP,
+		"baseAttack": baseAttack,
+		"baseDefense": baseDefense,
+		"baseSpAttack": baseSpAttack,
+		"baseSpDefense": baseSpDefense,
+		"baseSpeed": baseSpeed,
+		"baseMovePattern": _resource_to_path(baseMovePattern),
+		"baseAttackPattern": _resource_to_path(baseAttackPattern),
+		"innateAbility": innateAbility,
+		"hiddenAbility": hiddenAbility,
+		"learneableAbilities": learneableAbilities.duplicate()
+	}
+
+	data["level5Upgrades"] = _resources_to_paths(level5Upgrades)
+	data["level10Upgrades"] = _resources_to_paths(level10Upgrades)
+	data["level15Upgrades"] = _resources_to_paths(level15Upgrades)
+	data["level20Upgrades"] = _resources_to_paths(level20Upgrades)
+
+	return data
+
+static func fromDict(data: Dictionary) -> MeteormyteSpeciesData:
+
+	var species := MeteormyteSpeciesData.new()
+	species.speciesName = data.get("speciesName", species.speciesName)
+	species.speciesID = data.get("speciesID", species.speciesID)
+	species.description = data.get("description", species.description)
+	species.icon = _load_resource(data.get("icon", ""))
+	species.model = _load_resource(data.get("model", ""))
+	species.baseHP = data.get("baseHP", species.baseHP)
+	species.baseAttack = data.get("baseAttack", species.baseAttack)
+	species.baseDefense = data.get("baseDefense", species.baseDefense)
+	species.baseSpAttack = data.get("baseSpAttack", species.baseSpAttack)
+	species.baseSpDefense = data.get("baseSpDefense", species.baseSpDefense)
+	species.baseSpeed = data.get("baseSpeed", species.baseSpeed)
+	species.baseMovePattern = _load_resource(data.get("baseMovePattern", ""))
+	species.baseAttackPattern = _load_resource(data.get("baseAttackPattern", ""))
+	species.innateAbility = data.get("innateAbility", species.innateAbility)
+	species.hiddenAbility = data.get("hiddenAbility", species.hiddenAbility)
+	var abilities_variant := data.get("learneableAbilities", species.learneableAbilities)
+	if abilities_variant is Array:
+		species.learneableAbilities = abilities_variant.duplicate()
+
+	species.level5Upgrades = _load_resource_array(data.get("level5Upgrades", []))
+	species.level10Upgrades = _load_resource_array(data.get("level10Upgrades", []))
+	species.level15Upgrades = _load_resource_array(data.get("level15Upgrades", []))
+	species.level20Upgrades = _load_resource_array(data.get("level20Upgrades", []))
+
+	return species
+
+static func _resource_to_path(resource: Resource) -> String:
+
+	if resource and not resource.resource_path.is_empty():
+		return resource.resource_path
+	return ""
+
+static func _resources_to_paths(resources: Array) -> Array:
+
+	var paths: Array = []
+	for resource in resources:
+		paths.append(_resource_to_path(resource))
+	return paths
+
+static func _load_resource(path: String) -> Resource:
+
+	if typeof(path) != TYPE_STRING or path.is_empty():
+		return null
+	return ResourceLoader.load(path)
+
+static func _load_resource_array(paths: Array) -> Array:
+
+	var result: Array = []
+	for path in paths:
+		if typeof(path) == TYPE_STRING and not path.is_empty():
+			var resource := _load_resource(path)
+			if resource:
+				result.append(resource)
+	return result

--- a/Resources/MeteormyteStat.gd
+++ b/Resources/MeteormyteStat.gd
@@ -10,7 +10,7 @@ enum StatType {
 	SP_ATTACK,
 	SP_DEFENSE,
 	SPEED
-}
+	}
 
 #region Parameters
 @export var statType: StatType = StatType.HP
@@ -29,6 +29,9 @@ enum StatType {
 #region State
 var calculatedValue: int = 0  # The calculated stat value before modifiers
 #endregion
+
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "MeteormyteStat"
 
 func _init() -> void:
 	# Set hard limits based on stat type
@@ -106,3 +109,29 @@ func getIVQuality() -> String:
 func setLevel(newLevel: int) -> void:
 	level = newLevel
 	recalculateStats()
+
+func toDict() -> Dictionary:
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"statType": int(statType),
+		"baseStat": baseStat,
+		"individualValue": individualValue,
+		"effortValue": effortValue,
+		"level": level,
+		"gemCutModifier": gemCutModifier
+	}
+
+static func fromDict(data: Dictionary) -> MeteormyteStat:
+
+	var stat := MeteormyteStat.new()
+	var stat_type_value := data.get("statType", int(stat.statType))
+	stat.statType = StatType(stat_type_value)
+	stat.baseStat = data.get("baseStat", stat.baseStat)
+	stat.individualValue = data.get("individualValue", stat.individualValue)
+	stat.effortValue = data.get("effortValue", stat.effortValue)
+	stat.level = data.get("level", stat.level)
+	stat.gemCutModifier = data.get("gemCutModifier", stat.gemCutModifier)
+	stat.recalculateStats()
+	return stat

--- a/Resources/StatusEffectResource.gd
+++ b/Resources/StatusEffectResource.gd
@@ -8,7 +8,7 @@ enum EffectType {
 	BUFF,
 	DOT,  # Damage over time
 	HOT   # Heal over time
-}
+	}
 
 @export var effectName: String = "Unknown"
 @export var effectType: EffectType = EffectType.DEBUFF
@@ -38,14 +38,79 @@ enum EffectType {
 @export var preventsMovement: bool = false  # Like root
 @export var immunities: Array[String] = []  # Effect names this makes you immune to
 
+const SERIAL_VERSION := 1
+const RESOURCE_TYPE := "StatusEffectResource"
+
 ## Get damage for a given stack count
 func getDamageForStacks(stacks: int) -> int:
 	if not damageScalesWithStacks:
 		return damagePerTurn
-	
+
 	# Parse the formula string
 	var values := stackDamageFormula.split(",")
 	if stacks <= 0 or stacks > values.size():
 		return damagePerTurn
-	
+
 	return int(values[stacks - 1])
+
+func toDict() -> Dictionary:
+
+	return {
+		"version": SERIAL_VERSION,
+		"resource_type": RESOURCE_TYPE,
+		"effectName": effectName,
+		"effectType": int(effectType),
+		"icon": _resource_to_path(icon),
+		"baseDuration": baseDuration,
+		"maxStacks": maxStacks,
+		"stackable": stackable,
+		"refreshDurationOnStack": refreshDurationOnStack,
+		"isPersistent": isPersistent,
+		"statStages": statStages.duplicate(true),
+		"damagePerTurn": damagePerTurn,
+		"damageScalesWithStacks": damageScalesWithStacks,
+		"stackDamageFormula": stackDamageFormula,
+		"appliesOnTurnStart": appliesOnTurnStart,
+		"appliesOnTurnEnd": appliesOnTurnEnd,
+		"preventsAction": preventsAction,
+		"preventsMovement": preventsMovement,
+		"immunities": immunities.duplicate()
+	}
+
+static func fromDict(data: Dictionary) -> StatusEffectResource:
+
+	var status := StatusEffectResource.new()
+	status.effectName = data.get("effectName", status.effectName)
+	status.effectType = EffectType(data.get("effectType", int(status.effectType)))
+	status.icon = _load_resource(data.get("icon", ""))
+	status.baseDuration = data.get("baseDuration", status.baseDuration)
+	status.maxStacks = data.get("maxStacks", status.maxStacks)
+	status.stackable = data.get("stackable", status.stackable)
+	status.refreshDurationOnStack = data.get("refreshDurationOnStack", status.refreshDurationOnStack)
+	status.isPersistent = data.get("isPersistent", status.isPersistent)
+	var stat_stages_variant := data.get("statStages", status.statStages)
+	if stat_stages_variant is Dictionary:
+		status.statStages = stat_stages_variant.duplicate(true)
+	status.damagePerTurn = data.get("damagePerTurn", status.damagePerTurn)
+	status.damageScalesWithStacks = data.get("damageScalesWithStacks", status.damageScalesWithStacks)
+	status.stackDamageFormula = data.get("stackDamageFormula", status.stackDamageFormula)
+	status.appliesOnTurnStart = data.get("appliesOnTurnStart", status.appliesOnTurnStart)
+	status.appliesOnTurnEnd = data.get("appliesOnTurnEnd", status.appliesOnTurnEnd)
+	status.preventsAction = data.get("preventsAction", status.preventsAction)
+	status.preventsMovement = data.get("preventsMovement", status.preventsMovement)
+	var immunities_variant := data.get("immunities", status.immunities)
+	if immunities_variant is Array:
+		status.immunities = immunities_variant.duplicate()
+	return status
+
+static func _resource_to_path(resource: Resource) -> String:
+
+	if resource and not resource.resource_path.is_empty():
+		return resource.resource_path
+	return ""
+
+static func _load_resource(path: String) -> Resource:
+
+	if typeof(path) != TYPE_STRING or path.is_empty():
+		return null
+	return ResourceLoader.load(path)

--- a/Tests/Serialization/ResourceSerializationTest.gd
+++ b/Tests/Serialization/ResourceSerializationTest.gd
@@ -1,0 +1,390 @@
+extends GutTest
+
+func test_meteormyte_stat_round_trip() -> void:
+	var original := MeteormyteStat.new()
+	original.statType = MeteormyteStat.StatType.ATTACK
+	original.baseStat = 75
+	original.individualValue = 10
+	original.effortValue = 120
+	original.level = 12
+	original.gemCutModifier = 0.1
+	original.recalculateStats()
+
+	var serialized := original.toDict()
+	var from_dict := MeteormyteStat.fromDict(serialized)
+
+	var manual := MeteormyteStat.new()
+	manual.statType = MeteormyteStat.StatType.ATTACK
+	manual.baseStat = 75
+	manual.individualValue = 10
+	manual.effortValue = 120
+	manual.level = 12
+	manual.gemCutModifier = 0.1
+	manual.recalculateStats()
+
+	assert_eq(from_dict.statType, manual.statType, "Stat type should match")
+	assert_eq(from_dict.baseStat, manual.baseStat, "Base stat should match")
+	assert_eq(from_dict.individualValue, manual.individualValue, "IV should match")
+	assert_eq(from_dict.effortValue, manual.effortValue, "EV should match")
+	assert_eq(from_dict.level, manual.level, "Level should match")
+	assert_almost_eq(from_dict.gemCutModifier, manual.gemCutModifier, 0.0001, "Gem modifier should match")
+	assert_eq(from_dict.toDict(), serialized, "Serializing after deserializing should reproduce the same data")
+
+func test_board_pattern_round_trip() -> void:
+	var original := BoardPattern.new()
+	original.offsets = [Vector3i(1, 0, 0), Vector3i(0, 1, 0)]
+
+	var serialized := original.toDict()
+	var from_dict := BoardPattern.fromDict(serialized)
+
+	var manual := BoardPattern.new()
+	manual.offsets = [Vector3i(1, 0, 0), Vector3i(0, 1, 0)]
+
+	assert_eq(from_dict.offsets, manual.offsets, "Offsets should round trip")
+	assert_eq(from_dict.toDict(), serialized, "BoardPattern serialization should be stable")
+
+func test_gem_data_round_trip() -> void:
+	var original := GemData.new()
+	original.quality = GemData.GemQuality.EPIC
+	original.cut = GemData.GemCut.BALANCED
+	original.customCutName = "Prismatic"
+
+	var serialized := original.toDict()
+	var from_dict := GemData.fromDict(serialized)
+
+	var manual := GemData.new()
+	manual.quality = GemData.GemQuality.EPIC
+	manual.cut = GemData.GemCut.BALANCED
+	manual.customCutName = "Prismatic"
+
+	assert_eq(int(from_dict.quality), int(manual.quality), "Gem quality should match")
+	assert_eq(int(from_dict.cut), int(manual.cut), "Gem cut should match")
+	assert_eq(from_dict.customCutName, manual.customCutName, "Custom cut name should match")
+	assert_eq(from_dict.toDict(), serialized, "GemData serialization should be stable")
+
+func test_status_effect_round_trip() -> void:
+	var original := StatusEffectResource.new()
+	original.effectName = "Soothing Aura"
+	original.effectType = StatusEffectResource.EffectType.BUFF
+	original.baseDuration = 4
+	original.maxStacks = 2
+	original.stackable = true
+	original.refreshDurationOnStack = false
+	original.isPersistent = true
+	original.statStages = {"Attack": -2}
+	original.damagePerTurn = 3
+	original.damageScalesWithStacks = false
+	original.stackDamageFormula = "3,3,3"
+	original.appliesOnTurnStart = true
+	original.appliesOnTurnEnd = false
+	original.preventsAction = false
+	original.preventsMovement = true
+	original.immunities = ["Burn"]
+
+	var serialized := original.toDict()
+	var from_dict := StatusEffectResource.fromDict(serialized)
+
+	var manual := StatusEffectResource.new()
+	manual.effectName = "Soothing Aura"
+	manual.effectType = StatusEffectResource.EffectType.BUFF
+	manual.baseDuration = 4
+	manual.maxStacks = 2
+	manual.stackable = true
+	manual.refreshDurationOnStack = false
+	manual.isPersistent = true
+	manual.statStages = {"Attack": -2}
+	manual.damagePerTurn = 3
+	manual.damageScalesWithStacks = false
+	manual.stackDamageFormula = "3,3,3"
+	manual.appliesOnTurnStart = true
+	manual.appliesOnTurnEnd = false
+	manual.preventsAction = false
+	manual.preventsMovement = true
+	manual.immunities = ["Burn"]
+
+	assert_eq(from_dict.effectName, manual.effectName, "Effect name should match")
+	assert_eq(int(from_dict.effectType), int(manual.effectType), "Effect type should match")
+	assert_eq(from_dict.baseDuration, manual.baseDuration, "Duration should match")
+	assert_eq(from_dict.maxStacks, manual.maxStacks, "Max stacks should match")
+	assert_eq(from_dict.stackable, manual.stackable, "Stackable flag should match")
+	assert_eq(from_dict.refreshDurationOnStack, manual.refreshDurationOnStack, "Refresh behavior should match")
+	assert_eq(from_dict.isPersistent, manual.isPersistent, "Persistence should match")
+	assert_eq(from_dict.statStages, manual.statStages, "Stat stages should match")
+	assert_eq(from_dict.damagePerTurn, manual.damagePerTurn, "Damage per turn should match")
+	assert_eq(from_dict.damageScalesWithStacks, manual.damageScalesWithStacks, "Stack scaling should match")
+	assert_eq(from_dict.stackDamageFormula, manual.stackDamageFormula, "Damage formula should match")
+	assert_eq(from_dict.appliesOnTurnStart, manual.appliesOnTurnStart, "Turn start application should match")
+	assert_eq(from_dict.appliesOnTurnEnd, manual.appliesOnTurnEnd, "Turn end application should match")
+	assert_eq(from_dict.preventsAction, manual.preventsAction, "Action prevention should match")
+	assert_eq(from_dict.preventsMovement, manual.preventsMovement, "Movement prevention should match")
+	assert_eq(from_dict.immunities, manual.immunities, "Immunities should match")
+	assert_eq(from_dict.toDict(), serialized, "StatusEffectResource serialization should be stable")
+
+func test_hazard_resource_round_trip() -> void:
+	var original := HazardResource.new()
+	original.hazardName = "Flame Patch"
+	original.baseDuration = 5
+	original.maxStacks = 3
+	original.stackable = true
+	original.damageOnEnter = 10
+	original.damagePerTurn = 6
+	original.clearableByTypes = ["water"]
+	original.clearsOnExit = true
+	original.affectsFactions = 3
+	original.blockMovement = true
+	original.blockVision = true
+
+	var serialized := original.toDict()
+	var from_dict := HazardResource.fromDict(serialized)
+
+	var manual := HazardResource.new()
+	manual.hazardName = "Flame Patch"
+	manual.baseDuration = 5
+	manual.maxStacks = 3
+	manual.stackable = true
+	manual.damageOnEnter = 10
+	manual.damagePerTurn = 6
+	manual.clearableByTypes = ["water"]
+	manual.clearsOnExit = true
+	manual.affectsFactions = 3
+	manual.blockMovement = true
+	manual.blockVision = true
+
+	assert_eq(from_dict.hazardName, manual.hazardName, "Hazard name should match")
+	assert_eq(from_dict.baseDuration, manual.baseDuration, "Hazard duration should match")
+	assert_eq(from_dict.maxStacks, manual.maxStacks, "Hazard stacks should match")
+	assert_eq(from_dict.stackable, manual.stackable, "Stackable flag should match")
+	assert_eq(from_dict.damageOnEnter, manual.damageOnEnter, "Damage on enter should match")
+	assert_eq(from_dict.damagePerTurn, manual.damagePerTurn, "Damage per turn should match")
+	assert_eq(from_dict.clearableByTypes, manual.clearableByTypes, "Clearable types should match")
+	assert_eq(from_dict.clearsOnExit, manual.clearsOnExit, "Clears on exit should match")
+	assert_eq(from_dict.affectsFactions, manual.affectsFactions, "Affects factions should match")
+	assert_eq(from_dict.blockMovement, manual.blockMovement, "Block movement flag should match")
+	assert_eq(from_dict.blockVision, manual.blockVision, "Block vision flag should match")
+	assert_eq(from_dict.toDict(), serialized, "HazardResource serialization should be stable")
+
+func test_meteormyte_level_upgrade_round_trip() -> void:
+	var original := MeteormyteLevelUpgrade.new()
+	original.upgradeType = MeteormyteLevelUpgrade.UpgradeType.STAT_BOOST
+	original.upgradeName = "Sharpened Claws"
+	original.description = "Boost attack power"
+	original.effectData = {MeteormyteStat.StatType.ATTACK: 5}
+
+	var serialized := original.toDict()
+	var from_dict := MeteormyteLevelUpgrade.fromDict(serialized)
+
+	var manual := MeteormyteLevelUpgrade.new()
+	manual.upgradeType = MeteormyteLevelUpgrade.UpgradeType.STAT_BOOST
+	manual.upgradeName = "Sharpened Claws"
+	manual.description = "Boost attack power"
+	manual.effectData = {MeteormyteStat.StatType.ATTACK: 5}
+
+	assert_eq(int(from_dict.upgradeType), int(manual.upgradeType), "Upgrade type should match")
+	assert_eq(from_dict.upgradeName, manual.upgradeName, "Upgrade name should match")
+	assert_eq(from_dict.description, manual.description, "Upgrade description should match")
+	assert_eq(from_dict.effectData, manual.effectData, "Effect data should match")
+	assert_eq(from_dict.toDict(), serialized, "MeteormyteLevelUpgrade serialization should be stable")
+
+func test_meteormyte_species_data_round_trip() -> void:
+	var original := MeteormyteSpeciesData.new()
+	original.speciesName = "Pyron"
+	original.speciesID = 101
+	original.description = "Fiery insectoid"
+	original.baseHP = 70
+	original.baseAttack = 80
+	original.baseDefense = 60
+	original.baseSpAttack = 85
+	original.baseSpDefense = 55
+	original.baseSpeed = 90
+	original.innateAbility = "Blaze Shield"
+	original.hiddenAbility = "Molten Core"
+	original.learneableAbilities = ["Heat Up", "Wing Gust"]
+
+	var serialized := original.toDict()
+	var from_dict := MeteormyteSpeciesData.fromDict(serialized)
+
+	var manual := MeteormyteSpeciesData.new()
+	manual.speciesName = "Pyron"
+	manual.speciesID = 101
+	manual.description = "Fiery insectoid"
+	manual.baseHP = 70
+	manual.baseAttack = 80
+	manual.baseDefense = 60
+	manual.baseSpAttack = 85
+	manual.baseSpDefense = 55
+	manual.baseSpeed = 90
+	manual.innateAbility = "Blaze Shield"
+	manual.hiddenAbility = "Molten Core"
+	manual.learneableAbilities = ["Heat Up", "Wing Gust"]
+
+	assert_eq(from_dict.speciesName, manual.speciesName, "Species name should match")
+	assert_eq(from_dict.speciesID, manual.speciesID, "Species ID should match")
+	assert_eq(from_dict.description, manual.description, "Description should match")
+	assert_eq(from_dict.baseHP, manual.baseHP, "Base HP should match")
+	assert_eq(from_dict.baseAttack, manual.baseAttack, "Base attack should match")
+	assert_eq(from_dict.baseDefense, manual.baseDefense, "Base defense should match")
+	assert_eq(from_dict.baseSpAttack, manual.baseSpAttack, "Base special attack should match")
+	assert_eq(from_dict.baseSpDefense, manual.baseSpDefense, "Base special defense should match")
+	assert_eq(from_dict.baseSpeed, manual.baseSpeed, "Base speed should match")
+	assert_eq(from_dict.innateAbility, manual.innateAbility, "Innate ability should match")
+	assert_eq(from_dict.hiddenAbility, manual.hiddenAbility, "Hidden ability should match")
+	assert_eq(from_dict.learneableAbilities, manual.learneableAbilities, "Learneable abilities should match")
+	assert_eq(from_dict.toDict(), serialized, "MeteormyteSpeciesData serialization should be stable")
+
+func test_attack_resource_round_trip() -> void:
+	var original := AttackResource.new()
+	original.attackName = "Solar Lance"
+	original.description = "Piercing solar beam"
+	original.baseDamage = 120
+	original.accuracy = 0.85
+	original.damageType = AttackResource.Typing.GRASS
+	original.attackType = AttackResource.AttackType.SPECIAL
+	original.interactionType = AttackResource.InteractionType.RANGED
+	original.requiresTarget = true
+	original.canTargetEmpty = true
+	original.hitsAllies = true
+	original.aoeType = AttackResource.AOEType.AREA
+	original.chainCount = 2
+	original.chainRange = 3
+	original.statusChance = 0.5
+	original.hazardChance = 0.4
+	original.knockback = true
+	original.superKnockback = true
+	original.knockbackDistance = 2
+	original.vfxType = AttackResource.VFXType.BEAM
+	original.vfxScale = 1.5
+	original.vfxHeight = 0.25
+	original.vfxOrientation = AttackResource.VFXOrientation.ALONG_X
+	original.vfxRotationOffset = Vector3(10.0, 20.0, 30.0)
+	original.animationName = "beam"
+	original.animationTime = 2.0
+	original.selfDamagePercent = 0.2
+	original.drainsHealth = true
+	original.ignoresDefense = true
+
+	var serialized := original.toDict()
+	var from_dict := AttackResource.fromDict(serialized)
+
+	var manual := AttackResource.new()
+	manual.attackName = "Solar Lance"
+	manual.description = "Piercing solar beam"
+	manual.baseDamage = 120
+	manual.accuracy = 0.85
+	manual.damageType = AttackResource.Typing.GRASS
+	manual.attackType = AttackResource.AttackType.SPECIAL
+	manual.interactionType = AttackResource.InteractionType.RANGED
+	manual.requiresTarget = true
+	manual.canTargetEmpty = true
+	manual.hitsAllies = true
+	manual.aoeType = AttackResource.AOEType.AREA
+	manual.chainCount = 2
+	manual.chainRange = 3
+	manual.statusChance = 0.5
+	manual.hazardChance = 0.4
+	manual.knockback = true
+	manual.superKnockback = true
+	manual.knockbackDistance = 2
+	manual.vfxType = AttackResource.VFXType.BEAM
+	manual.vfxScale = 1.5
+	manual.vfxHeight = 0.25
+	manual.vfxOrientation = AttackResource.VFXOrientation.ALONG_X
+	manual.vfxRotationOffset = Vector3(10.0, 20.0, 30.0)
+	manual.animationName = "beam"
+	manual.animationTime = 2.0
+	manual.selfDamagePercent = 0.2
+	manual.drainsHealth = true
+	manual.ignoresDefense = true
+
+	assert_eq(from_dict.attackName, manual.attackName, "Attack name should match")
+	assert_eq(from_dict.description, manual.description, "Description should match")
+	assert_eq(from_dict.baseDamage, manual.baseDamage, "Base damage should match")
+	assert_almost_eq(from_dict.accuracy, manual.accuracy, 0.0001, "Accuracy should match")
+	assert_eq(int(from_dict.damageType), int(manual.damageType), "Damage type should match")
+	assert_eq(int(from_dict.attackType), int(manual.attackType), "Attack type should match")
+	assert_eq(int(from_dict.interactionType), int(manual.interactionType), "Interaction type should match")
+	assert_eq(from_dict.requiresTarget, manual.requiresTarget, "Requires target flag should match")
+	assert_eq(from_dict.canTargetEmpty, manual.canTargetEmpty, "Can target empty flag should match")
+	assert_eq(from_dict.hitsAllies, manual.hitsAllies, "Hits allies flag should match")
+	assert_eq(int(from_dict.aoeType), int(manual.aoeType), "AOE type should match")
+	assert_eq(from_dict.chainCount, manual.chainCount, "Chain count should match")
+	assert_eq(from_dict.chainRange, manual.chainRange, "Chain range should match")
+	assert_almost_eq(from_dict.statusChance, manual.statusChance, 0.0001, "Status chance should match")
+	assert_almost_eq(from_dict.hazardChance, manual.hazardChance, 0.0001, "Hazard chance should match")
+	assert_eq(from_dict.knockback, manual.knockback, "Knockback flag should match")
+	assert_eq(from_dict.superKnockback, manual.superKnockback, "Super knockback flag should match")
+	assert_eq(from_dict.knockbackDistance, manual.knockbackDistance, "Knockback distance should match")
+	assert_eq(int(from_dict.vfxType), int(manual.vfxType), "VFX type should match")
+	assert_almost_eq(from_dict.vfxScale, manual.vfxScale, 0.0001, "VFX scale should match")
+	assert_almost_eq(from_dict.vfxHeight, manual.vfxHeight, 0.0001, "VFX height should match")
+	assert_eq(int(from_dict.vfxOrientation), int(manual.vfxOrientation), "VFX orientation should match")
+	assert_true(from_dict.vfxRotationOffset.is_equal_approx(manual.vfxRotationOffset), "VFX rotation offset should match")
+	assert_eq(from_dict.animationName, manual.animationName, "Animation name should match")
+	assert_almost_eq(from_dict.animationTime, manual.animationTime, 0.0001, "Animation time should match")
+	assert_almost_eq(from_dict.selfDamagePercent, manual.selfDamagePercent, 0.0001, "Self damage percent should match")
+	assert_eq(from_dict.drainsHealth, manual.drainsHealth, "Drains health flag should match")
+	assert_eq(from_dict.ignoresDefense, manual.ignoresDefense, "Ignores defense flag should match")
+	assert_eq(from_dict.toDict(), serialized, "AttackResource serialization should be stable")
+
+func test_meteormyte_round_trip() -> void:
+	var original := Meteormyte.new()
+	original.nickname = "Blazebug"
+	original.level = 7
+	original.xp = 250
+	original.unique_id = 424242
+	original.current_hp = 35
+
+	var hp_stat := MeteormyteStat.new()
+	hp_stat.statType = MeteormyteStat.StatType.HP
+	hp_stat.baseStat = 70
+	hp_stat.individualValue = 12
+	hp_stat.level = 7
+	hp_stat.recalculateStats()
+	original.stats[MeteormyteStat.StatType.HP] = hp_stat
+
+	var atk_stat := MeteormyteStat.new()
+	atk_stat.statType = MeteormyteStat.StatType.ATTACK
+	atk_stat.baseStat = 80
+	atk_stat.individualValue = 8
+	atk_stat.level = 7
+	atk_stat.recalculateStats()
+	original.stats[MeteormyteStat.StatType.ATTACK] = atk_stat
+
+	var serialized := original.toDict()
+	var from_dict := Meteormyte.fromDict(serialized)
+
+	var manual := Meteormyte.new()
+	manual.nickname = "Blazebug"
+	manual.level = 7
+	manual.xp = 250
+	manual.unique_id = 424242
+	manual.current_hp = 35
+
+	var manual_hp := MeteormyteStat.new()
+	manual_hp.statType = MeteormyteStat.StatType.HP
+	manual_hp.baseStat = 70
+	manual_hp.individualValue = 12
+	manual_hp.level = 7
+	manual_hp.recalculateStats()
+	manual.stats[MeteormyteStat.StatType.HP] = manual_hp
+
+	var manual_atk := MeteormyteStat.new()
+	manual_atk.statType = MeteormyteStat.StatType.ATTACK
+	manual_atk.baseStat = 80
+	manual_atk.individualValue = 8
+	manual_atk.level = 7
+	manual_atk.recalculateStats()
+	manual.stats[MeteormyteStat.StatType.ATTACK] = manual_atk
+
+	assert_eq(from_dict.nickname, manual.nickname, "Nickname should match")
+	assert_eq(from_dict.level, manual.level, "Level should match")
+	assert_eq(from_dict.xp, manual.xp, "XP should match")
+	assert_eq(from_dict.unique_id, manual.unique_id, "Unique ID should match")
+	assert_eq(from_dict.current_hp, manual.current_hp, "Current HP should match")
+	assert_eq(from_dict.stats.size(), manual.stats.size(), "Stat count should match")
+
+	for stat_type in manual.stats.keys():
+		assert_true(from_dict.stats.has(stat_type), "Deserialized Meteormyte should have stat %s" % [stat_type])
+		assert_eq(from_dict.stats[stat_type].toDict(), manual.stats[stat_type].toDict(), "Stat %s should match after round trip" % [stat_type])
+
+	assert_eq(from_dict.available_attacks.size(), manual.available_attacks.size(), "Available attacks should match")
+	assert_eq(from_dict.toDict(), serialized, "Meteormyte serialization should be stable")


### PR DESCRIPTION
## Summary
- stop converting BoardPattern offsets into dictionaries during serialization and keep them as native Vector3i arrays
- adjust deserialization to accept the native Vector3i entries while preserving existing metadata headers

## Testing
- godot --headless --test *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4aa933b88324b17bb8261c4814ba